### PR TITLE
Remove the int from cache function

### DIFF
--- a/src/Gracenote.php
+++ b/src/Gracenote.php
@@ -31,7 +31,7 @@ class Gracenote
      * Sets the time in minutes to cache the search results
      * @param  integer $cache A number of minutes
      */
-    public function cache(int $cache)
+    public function cache($cache)
     {
         $this->cache = $cache;
         return $this;


### PR DESCRIPTION
I tried to use your package, got an error that your code expected an int somewhere. No need for that, without the 'int' it's working properly.